### PR TITLE
Return original Gemfile line when gem version can not be resolved.

### DIFF
--- a/lib/version_gemfile/versioner.rb
+++ b/lib/version_gemfile/versioner.rb
@@ -57,6 +57,9 @@ module VersionGemfile
 
       name    = gem_name(gem_line)
       version = get_version(name)
+
+      return gem_line unless version
+
       options = gem_line.gsub(GET_GEM_NAME, '').strip
       "#{spaces(gem_line)}gem '#{name}', '~> #{version}'#{options}"
     end

--- a/spec/support/Gemfile.final.test
+++ b/spec/support/Gemfile.final.test
@@ -25,3 +25,4 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
 end
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/spec/support/Gemfile.initial.test
+++ b/spec/support/Gemfile.initial.test
@@ -25,3 +25,4 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
 end
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION



### What is the issue?

When you set up, for example, [a new Rails 6 project](https://guides.rubyonrails.org/command_line.html#rails-new), your `Gemfile` contains the following line by default:
```
gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
```
If you are using [ruby platform](https://bundler.io/v2.2/man/gemfile.5.html#PLATFORMS) and this platform is not listed in `platforms: [:mingw, :mswin, :x64_mingw, :jruby]`, `bundle install` does not install `tzinfo-data`.

As a result, `bundle exec version_gemfile` can not resolve `tzinfo-data` version in `Gemfile.lock` and places something  like so to the updated `Gemfile`:

```
gem 'tzinfo-data', '~> ', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
```

Which, in turn, leads to the following error when starting a rails server:

```
bundle exec rails server

[!] There was an error parsing `Gemfile`: Illformed requirement ["~> "]. Bundler cannot continue.

 #  from /app/Gemfile:16
 #  -------------------------------------------
 #  gem 'turbolinks', '~> 5'
 >  gem 'tzinfo-data', '~> ', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 #  gem 'webpacker', '~> 5.0'
 #  -------------------------------------------
```

### What does this PR do? 

- It tries to fix the issue described above by returning the original `Gemfile` line when version can not be resolved.

- It updates specs.

### How to test?

- Setup `version_gemfile` on the local machine.

```bash
git clone https://github.com/nhocki/version_gemfile.git

cd version_gemfile

bundle install
```

- Add `gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]` to `spec/support/Gemfile.initial.test` and `spec/support/Gemfile.final.test`.

- Run specs.

```bash
bundle exec rspec
```

- Or create a new Rails project on [ruby platform](https://bundler.io/v2.2/man/gemfile.5.html#PLATFORMS), add `gem 'version_gemfile'` to its `Gemfile` and run `bundle exec version_gemfile` inside of it.

