### PR TITLE
--gemfile and --gemfile-lock options

### DIFF
--- a/bin/version_gemfile
+++ b/bin/version_gemfile
@@ -8,8 +8,12 @@ options = {}
 opt_parser = OptionParser.new do |opts|
   opts.banner = "Usage: version_gemfile [options]"
 
-  opts.on("-g", "--gemfile", "Gemfile path") do |path|
+  opts.on("-g", "--gemfile STRING", "Gemfile path") do |path|
     options[:gemfile] = path
+  end
+
+  opts.on("-l", "--gemfile-lock STRING", "Gemfile.lock path") do |path|
+    options[:gemfile_lock] = path
   end
 end
 

--- a/lib/version_gemfile/versioner.rb
+++ b/lib/version_gemfile/versioner.rb
@@ -17,7 +17,7 @@ module VersionGemfile
     def initialize(options = {})
       @options = normalize_hash(options.clone)
       @gemfile_path = @options.fetch('gemfile'){ 'Gemfile' }
-      @lockfile_path = "#{@gemfile_path}.lock"
+      @lockfile_path = @options.fetch('gemfile_lock'){ "#{@gemfile_path}.lock" }
 
       @lock_contents   = File.read(lockfile_path)
       @gemfile_content = File.readlines(gemfile_path)


### PR DESCRIPTION
### What is the issue?

1. When you pass `--gemfile` option to the `version_gemfile` command, [this option is ignored](https://github.com/marian13/version_gemfile/commit/6bf174ecabe67c5f49ef84dcee7962abc3ae15a6#diff-37093e233cd7bc686997aa7c3980c5330bae9dbf1019ed5f9a3225505c5cd6f6L11).
  
   For example: 
   ```bash
   bundle exec version_gemfile --gemfile CustomGemfile
   ``` 

2. It is not possible to use a `Gemfile.lock` with a custom name.

    [You need to follow this rule](https://github.com/marian13/version_gemfile/commit/6bf174ecabe67c5f49ef84dcee7962abc3ae15a6#diff-ff62afd40d863a72ded56d533353865a9a705f0dde3838399d10b107a036a26bL20):

    If `Gemfile` is named as `CustomGemfile`, then `Gemfile.lock` must be named as `CustomGemfile.lock`.
   
### What does this PR do? 

- Updates [OptionsParser](https://ruby-doc.org/stdlib-3.0.1/libdoc/optparse/rdoc/OptionParser.html) to respect `--gemfile` option.

- Allows to pass custom `Gemfile.lock` by the newly introduced `--gemfile-lock` option.
