### PR TITLE
Add --gem-command-quote option

### DIFF
--- a/bin/version_gemfile
+++ b/bin/version_gemfile
@@ -15,6 +15,10 @@ opt_parser = OptionParser.new do |opts|
   opts.on("-l", "--gemfile-lock STRING", "Gemfile.lock path") do |path|
     options[:gemfile_lock] = path
   end
+
+  opts.on("-q", "--gem-command-quote STRING", "Gem command quote") do |quote|
+    options[:gem_command_quote] = quote
+  end
 end
 
 opt_parser.parse!


### PR DESCRIPTION
### What does this PR do? 

- Updates [OptionsParser](https://ruby-doc.org/stdlib-3.0.1/libdoc/optparse/rdoc/OptionParser.html) to respect `--gem-command-quote` option.

  It allows deciding which type of quotes to use in Gemfile when a missing version to a gem is added.
  
  For example:

  ```ruby
  # version_gemfile --gem-command-quote '"'
  
  gem "rails", "~> 6.1.4"
  
  # version_gemfile --gem-command-quote '\''
  
  gem 'rails', '~> 6.1.4'
  ```
